### PR TITLE
feat(security): add auth middleware and input validation to scan and spam routes

### DIFF
--- a/src/routes/scan.route.js
+++ b/src/routes/scan.route.js
@@ -1,9 +1,11 @@
 import express from "express";
 import { scan } from "../controllers/scan.controller.js";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { validate, scanSchema } from "../utils/validation/auth.validation.js";
 
 const router = express.Router();
 
-// POST /scan
-router.post("/scan", scan);
+// POST /api/scan
+router.post("/scan", authMiddleware, validate(scanSchema), scan);
 
 export default router;

--- a/src/routes/spam.route.js
+++ b/src/routes/spam.route.js
@@ -1,9 +1,11 @@
-import express from 'express'
-import spamController from '../controllers/spam.controller.js';
+import express from "express";
+import spamController from "../controllers/spam.controller.js";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { validate, spamSchema } from "../utils/validation/auth.validation.js";
 
 const router = express.Router();
 
-// POST /textChecker
-router.post('/textChecker', spamController.checkSpamMessage)
+// POST /api/spam/textChecker
+router.post("/textChecker", authMiddleware, validate(spamSchema), spamController.checkSpamMessage);
 
 export default router;

--- a/src/utils/validation/auth.validation.js
+++ b/src/utils/validation/auth.validation.js
@@ -87,3 +87,23 @@ export const resetPasswordSchema = z
             .regex(/^\d{6}$/, `OTP must be 6 digits.`),
     })
     .strict();
+
+export const scanSchema = z
+    .object({
+        message: z
+            .string({ required_error: "Message is required." })
+            .trim()
+            .min(1, "Message cannot be empty.")
+            .max(1000, "Message is too long."),
+    })
+    .strict();
+
+export const spamSchema = z
+    .object({
+        message: z
+            .string({ required_error: "Message is required." })
+            .trim()
+            .min(1, "Message cannot be empty.")
+            .max(1000, "Message is too long."),
+    })
+    .strict();


### PR DESCRIPTION
## Summary
Adds JWT authentication middleware and Zod input validation to the /api/scan and /api/spam/textChecker endpoints which were previously unprotected.

## Changes
- Added `scanSchema` and `spamSchema` Zod validators to `auth.validation.js`
- Added `authMiddleware` and `validate(scanSchema)` to `scan.route.js`
- Added `authMiddleware` and `validate(spamSchema)` to `spam.route.js`

## Testing
- Verified both endpoints return 401 Unauthorized without a JWT token
- Verified auth check runs before validation

## Planner Task
Add auth middleware and input validation to scan and spam routes