### PR TITLE
feat(security): add phone number reputation check service and integra…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
 
         "express-rate-limit": "^8.1.0",
 
+        "google-libphonenumber": "^3.2.44",
+
         "helmet": "^8.1.0",
 
         "jsonwebtoken": "^9.0.2",
@@ -2355,6 +2357,24 @@
       "engines": {
 
         "node": ">= 6"
+
+      }
+
+    },
+
+    "node_modules/google-libphonenumber": {
+
+      "version": "3.2.44",
+
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.44.tgz",
+
+      "integrity": "sha512-9p2TghluF2LTChFMLWsDRD5N78SZDsILdUk4gyqYxBXluCyxoPiOq+Fqt7DKM+LUd33+OgRkdrc+cPR93AypCQ==",
+
+      "license": "(MIT AND Apache-2.0)",
+
+      "engines": {
+
+        "node": ">=0.10"
 
       }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 
     "express-rate-limit": "^8.1.0",
 
+    "google-libphonenumber": "^3.2.44",
+
     "helmet": "^8.1.0",
 
     "jsonwebtoken": "^9.0.2",

--- a/src/controllers/scan.controller.js
+++ b/src/controllers/scan.controller.js
@@ -1,13 +1,14 @@
 import axios from "axios";
+import { checkPhoneReputation } from "../services/phoneReputation.service.js";
 
 /**
  * POST /api/scan
  * Predicts whether an SMS message is a smishing attempt
- * @param {Object} req - Request object with message in body
+ * @param {Object} req - Request object with message and optional phoneNumber in body
  * @param {Object} res - Response object
  */
 export const scan = async (req, res) => {
-    const { message } = req.body;
+    const { message, phoneNumber } = req.body;
 
     if (!message) {
         return res.status(422).json({
@@ -19,9 +20,16 @@ export const scan = async (req, res) => {
         const response = await axios.post("http://localhost:5050/api/predict", { message });
         const { prediction, confidence } = response.data;
 
+        // Check phone number reputation if provided
+        let phoneReputation = null;
+        if (phoneNumber) {
+            phoneReputation = await checkPhoneReputation(phoneNumber);
+        }
+
         res.json({
             prediction,
             confidence,
+            phoneReputation,
         });
     } catch (error) {
         console.error("Prediction API error:", error.message);

--- a/src/routes/scan.route.js
+++ b/src/routes/scan.route.js
@@ -1,9 +1,11 @@
 import express from "express";
 import { scan } from "../controllers/scan.controller.js";
+import { authMiddleware } from "../middlewares/auth.middleware.js";
+import { validate, scanSchema } from "../utils/validation/auth.validation.js";
 
 const router = express.Router();
 
-// POST /scan
-router.post("/scan", scan);
+// POST /api/scan
+router.post("/scan", authMiddleware, validate(scanSchema), scan);
 
 export default router;

--- a/src/services/phoneReputation.service.js
+++ b/src/services/phoneReputation.service.js
@@ -1,0 +1,95 @@
+import pkg from "google-libphonenumber";
+const { PhoneNumberUtil, PhoneNumberType } = pkg;
+
+const phoneUtil = PhoneNumberUtil.getInstance();
+
+/**
+ * Analyses a phone number and returns reputation signals
+ * useful for smishing detection.
+ *
+ * @param {string} phoneNumber - The phone number to analyse
+ * @returns {object} - Reputation analysis result
+ */
+export async function checkPhoneReputation(phoneNumber) {
+    if (!phoneNumber || typeof phoneNumber !== "string") {
+        return { error: "Invalid phone number provided" };
+    }
+
+    try {
+        const cleaned = phoneNumber.trim();
+        const parsed = phoneUtil.parseAndKeepRawInput(cleaned, null);
+
+        const isValid = phoneUtil.isValidNumber(parsed);
+        const isPossible = phoneUtil.isPossibleNumber(parsed);
+        const countryCode = phoneUtil.getRegionCodeForNumber(parsed);
+        const numberType = phoneUtil.getNumberType(parsed);
+
+        // Map number type to human readable
+        const typeMap = {
+            [PhoneNumberType.FIXED_LINE]: "fixed_line",
+            [PhoneNumberType.MOBILE]: "mobile",
+            [PhoneNumberType.FIXED_LINE_OR_MOBILE]: "fixed_line_or_mobile",
+            [PhoneNumberType.TOLL_FREE]: "toll_free",
+            [PhoneNumberType.PREMIUM_RATE]: "premium_rate",
+            [PhoneNumberType.SHARED_COST]: "shared_cost",
+            [PhoneNumberType.VOIP]: "voip",
+            [PhoneNumberType.PERSONAL_NUMBER]: "personal_number",
+            [PhoneNumberType.PAGER]: "pager",
+            [PhoneNumberType.UAN]: "uan",
+            [PhoneNumberType.UNKNOWN]: "unknown",
+        };
+
+        const lineType = typeMap[numberType] ?? "unknown";
+
+        // Risk signals
+        const isVoip = lineType === "voip";
+        const isPremiumRate = lineType === "premium_rate";
+        const isTollFree = lineType === "toll_free";
+        const isUnknownType = lineType === "unknown";
+
+        // Compute risk score
+        let riskScore = 0;
+        if (!isValid) riskScore += 30;
+        if (isVoip) riskScore += 40;
+        if (isPremiumRate) riskScore += 35;
+        if (isUnknownType) riskScore += 20;
+        if (isTollFree) riskScore += 10;
+        riskScore = Math.min(riskScore, 100);
+
+        const isSuspicious = riskScore >= 40;
+
+        return {
+            phoneNumber: cleaned,
+            isValid,
+            isPossible,
+            countryCode: countryCode || "unknown",
+            lineType,
+            riskScore,
+            isSuspicious,
+            signals: {
+                isVoip,
+                isPremiumRate,
+                isTollFree,
+                isUnknownType,
+            },
+        };
+    } catch (err) {
+        console.error("Phone reputation error:", err.message);
+        return {
+            phoneNumber,
+            isValid: false,
+            isPossible: false,
+            countryCode: "unknown",
+            lineType: "unknown",
+            riskScore: 20,
+            isSuspicious: false,
+            signals: {
+                isVoip: false,
+                isPremiumRate: false,
+                isTollFree: false,
+                isUnknownType: true,
+            },
+            error: err.message,
+        };
+    }
+}

--- a/src/utils/validation/auth.validation.js
+++ b/src/utils/validation/auth.validation.js
@@ -87,3 +87,28 @@ export const resetPasswordSchema = z
             .regex(/^\d{6}$/, `OTP must be 6 digits.`),
     })
     .strict();
+
+export const scanSchema = z
+    .object({
+        message: z
+            .string({ required_error: "Message is required." })
+            .trim()
+            .min(1, "Message cannot be empty.")
+            .max(1000, "Message is too long."),
+        phoneNumber: z
+            .string()
+            .trim()
+            .regex(/^[+0-9()\-\s]{3,25}$/, "Invalid phone number format.")
+            .optional(),
+    })
+    .strict();
+
+export const spamSchema = z
+    .object({
+        message: z
+            .string({ required_error: "Message is required." })
+            .trim()
+            .min(1, "Message cannot be empty.")
+            .max(1000, "Message is too long."),
+    })
+    .strict();


### PR DESCRIPTION
## Summary
Implements a phone number reputation check service that analyses sender phone numbers for smishing risk signals. Currently the app analyses message text and URLs but never checks the sender's phone number. This adds a new layer of smishing detection by identifying suspicious number types commonly associated with smishing attacks.

## Changes
- Created `src/services/phoneReputation.service.js` using `google-libphonenumber` to validate and analyse phone numbers
- Service detects suspicious line types including VoIP, premium rate, and toll free numbers and computes a risk score
- Updated `src/controllers/scan.controller.js` to accept optional `phoneNumber` field and call the reputation service
- Updated `scanSchema` in `auth.validation.js` to include optional phone number validation
- Added `authMiddleware` and `validate(scanSchema)` to `scan.route.js`

## Testing
- Verified Australian mobile number (+61412345678) correctly returns lineType: mobile, riskScore: 0
- Verified premium rate number (+19005551234) correctly returns lineType: premium_rate, riskScore: 35, isPremiumRate: true
- Verified endpoint returns 401 Unauthorized without a valid JWT token

## Planner Task
Implement Phone Number Reputation Check Service