### PR TITLE
feat(detections): extend model and add saveDetection() for scan result storage

### DIFF
--- a/src/controllers/scan.controller.js
+++ b/src/controllers/scan.controller.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-
+import { saveDetection } from "../services/detections.service.js";
 /**
  * POST /api/scan
  * Predicts whether an SMS message is a smishing attempt
@@ -7,7 +7,7 @@ import axios from "axios";
  * @param {Object} res - Response object
  */
 export const scan = async (req, res) => {
-    const { message } = req.body;
+    const { message, phoneNumber } = req.body;
 
     if (!message) {
         return res.status(422).json({
@@ -18,6 +18,16 @@ export const scan = async (req, res) => {
     try {
         const response = await axios.post("http://localhost:5050/api/predict", { message });
         const { prediction, confidence } = response.data;
+
+        // Save detection result to MongoDB
+        await saveDetection({
+            messageContent: message,
+            phoneNumber: phoneNumber || "unknown",
+            result: prediction,
+            confidence: confidence,
+            advice: "",
+            source: "scan",
+        });
 
         res.json({
             prediction,

--- a/src/models/detections.model.js
+++ b/src/models/detections.model.js
@@ -17,6 +17,33 @@ const detectionsSchema = new mongoose.Schema({
         type: String,
         required: true,
     },
+
+    // Detection result fields added to store ML scan output
+    messageContent: {
+        type: String,
+        default: "",
+        trim: true,
+    },
+    result: {
+        type: String,
+        enum: ["smishing", "spam", "safe"],
+        default: "safe",
+    },
+    confidence: {
+        type: Number,
+        min: 0,
+        max: 1,
+        default: 0,
+    },
+    advice: {
+        type: String,
+        default: "",
+    },
+    source: {
+        type: String,
+        enum: ["scan", "report"],
+        default: "scan",
+    },
 });
 
 const Detections = mongoose.model("Detections", detectionsSchema);

--- a/src/services/detections.service.js
+++ b/src/services/detections.service.js
@@ -31,3 +31,19 @@ export const getFilteredDetections = async (filters) => {
 
     return csv;
 };
+// New function added to save ML scan results to MongoDB
+export const saveDetection = async ({ messageContent, phoneNumber, result, confidence, advice, source }) => {
+    const detection = await Detections.create({
+        timestamp: new Date(),
+        phoneNumber: phoneNumber || "unknown",
+        status: result,
+        type: source || "scan",
+        messageContent,
+        result,
+        confidence,
+        advice,
+        source: source || "scan",
+    });
+
+    return detection;
+};


### PR DESCRIPTION
This PR extends the existing detection flow to ensure scan results are saved to MongoDB after every scan.
Changes made: 
- Extended detections.model.js with new fields to store ML scan results (messageContent, result, confidence, advice, source)
- Added saveDetection() function in detections.service.js to persist scan results to MongoDB
- Updated scan.controller.js to call saveDetection() after every scan

Related Planner Task
Improve and Complete Detection Result Storage in MongoDB

Testing
Tested using Postman -  POST /api/scan returned 200 OK confirming the storage flow is working correctly.  
<img width="1280" height="761" alt="postman" src="https://github.com/user-attachments/assets/98f229d6-9f4d-4b8f-9e79-88fdadbbec7b" />

